### PR TITLE
Overrode UITabBarController methods so that they update the segmented control

### DIFF
--- a/SNFSegmentedViewController/SNFSegmentedViewController.h
+++ b/SNFSegmentedViewController/SNFSegmentedViewController.h
@@ -8,6 +8,11 @@
 
 #import <UIKit/UIKit.h>
 
+/**
+ * SNFSegmentedViewController is the simplest way to use a UISegmentedControl to switch between view controllers.
+ * Just set the view controllers property in code or in a storyboard.
+ * The UIViewController's title is used for the segmented control. If the title is nil, an empty string is used instead.
+ */
 @interface SNFSegmentedViewController : UITabBarController
 
 @property (strong, nonatomic, readonly) UISegmentedControl *segmentedControl;

--- a/SNFSegmentedViewController/SNFSegmentedViewController.m
+++ b/SNFSegmentedViewController/SNFSegmentedViewController.m
@@ -48,7 +48,7 @@
 
 #pragma mark - IB Action
 
-- (IBAction)segmentTapped:(UISegmentedControl *)sender {
+- (void)segmentTapped:(UISegmentedControl *)sender {
     self.selectedIndex = sender.selectedSegmentIndex;
 }
 
@@ -57,10 +57,10 @@
 - (void)configureForInitialization {
     self.delegate = self;
     
-    NSMutableArray *titles = [NSMutableArray arrayWithCapacity:[self.tabBar.items count]];
-    
+    NSMutableArray *titles = [NSMutableArray arrayWithCapacity:self.tabBar.items.count];
+	
     for (UITabBarItem *tabBarItem in self.tabBar.items) {
-        [titles addObject:tabBarItem.title];
+		[titles addObject:tabBarItem.title ?: @""];
     }
     
     _segmentedControl = [[UISegmentedControl alloc] initWithItems:[titles copy]];
@@ -89,6 +89,24 @@
     tabBar.frame = tabFrame;
     content.frame = window.bounds;
     
+}
+
+#pragma mark - UITabBarController overrides
+
+- (void)setSelectedIndex:(NSUInteger)selectedIndex {
+	[super setSelectedIndex:selectedIndex];
+	self.segmentedControl.selectedSegmentIndex = selectedIndex;
+}
+
+- (void)setSelectedViewController:(UIViewController *)selectedViewController {
+	[super setSelectedViewController:selectedViewController];
+	self.segmentedControl.selectedSegmentIndex = [self.viewControllers indexOfObject:selectedViewController];
+}
+
+//setViewControllers funnels to this method so we do not need to override that method.
+- (void)setViewControllers:(NSArray *)viewControllers animated:(BOOL)animated {
+	[super setViewControllers:viewControllers animated:animated];
+	[self configureForInitialization];
 }
 
 @end


### PR DESCRIPTION
Overrode UITabBarController methods so that they update the segmented control

Fixed a cash when the controller's title is nil.
Documented the header file.
